### PR TITLE
Removing check obsolete check for main.js

### DIFF
--- a/data/gui/jetinspector.js
+++ b/data/gui/jetinspector.js
@@ -174,8 +174,6 @@ function launch(package, dirType, testFileName) {
 }
 
 function Run() {
-  if (!hasMain)
-    return alert("You need a 'main.js' file in order to run an extension");
   document.location.href = "jetpack:" + currentPackage.name + ":run";
 }
 


### PR DESCRIPTION
Removing obsolete check that stops user from running packages that specify main other than main.js
